### PR TITLE
fix(mergeValues): check patch value which can be nullable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,7 +171,7 @@ export const setValueByPath = (obj: any, objPath: ObjPath, value: any, i = 0) =>
 export const mergeValues = (value: any, patch: any) => {
   if (Array.isArray(value)) {
     return Array.isArray(patch) ? value.push(...patch) : value
-  } else if (typeof value === "object" && typeof patch === "object") {
+  } else if (typeof value === "object" && typeof patch === "object" && patch) {
     for(const key of Reflect.ownKeys(patch)) {
       value[key] = mergeValues(value[key], patch[key])
     }


### PR DESCRIPTION
The method `mergeValues` accepts `patch` property that can be anything.
Inside the function body, there is a typecheck that ensures the type of the `patch` is `object`. But it can be null as well.

It results in a page crash for some specifications.