### PR TITLE
fix(naming): `deprecate` -> `deprecated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const diffs = apiDiff(oldSpec, newSpec)
 //   after: 'value in newSpec',
 //   before: 'value in oldSpec',
 //   path: ['path, 'in', 'array', 'format'],
-//   type: "annotation" | "breaking" | "non-breaking" | "unclassified" | "deprecate"
+//   type: "annotation" | "breaking" | "non-breaking" | "unclassified" | "deprecated"
 // }
 
 const merged = apiMerge(oldSpec, newSpec)
@@ -112,7 +112,7 @@ type Diff = {
   path: Array<string | number>
   before?: any
   after?: any
-  type: "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecate"
+  type: "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecated"
 }
 ```
 
@@ -137,7 +137,7 @@ type Diff = {
   action: "add" | "remove" | "replace" | "rename"
   before?: any
   after?: any
-  type: "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecate"
+  type: "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecated"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-smart-diff",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Generate the diff between two API specifications (OpenAPI, AsyncAPI, JsonSchema)",
   "module": "dist/esm/index.js",
   "main": "dist/cjs/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,10 +15,10 @@ export enum ClassifierType {
   nonBreaking = "non-breaking",
   annotation = "annotation",
   unclassified = "unclassified",
-  deprecate = "deprecate"
+  deprecated = "deprecated"
 }
 
-export const { breaking, nonBreaking, unclassified, annotation, deprecate } = ClassifierType
+export const { breaking, nonBreaking, unclassified, annotation, deprecated } = ClassifierType
 
 // predefined classifiers
 export const allNonBreaking: Rule = [nonBreaking, nonBreaking, nonBreaking]
@@ -27,4 +27,4 @@ export const onlyAddBreaking: Rule = [breaking, nonBreaking, nonBreaking]
 export const addNonBreaking: Rule = [nonBreaking, breaking, breaking]
 export const allUnclassified: Rule = [unclassified, unclassified, unclassified]
 export const allAnnotation: Rule = [annotation, annotation, annotation]
-export const allDeprecate: Rule = [deprecate, deprecate, deprecate]
+export const allDeprecated: Rule = [deprecated, deprecated, deprecated]

--- a/src/rules/jsonschema.ts
+++ b/src/rules/jsonschema.ts
@@ -3,7 +3,7 @@ import { DiffTypeFunc, Rule, Rules } from "../types"
 import {
   breaking, nonBreaking, addNonBreaking, 
   allAnnotation, allBreaking, allUnclassified,
-  onlyAddBreaking, allDeprecate,
+  onlyAddBreaking, allDeprecated,
 } from "../constants"
 
 const maxClassifier: Rule = [
@@ -103,7 +103,7 @@ export const jsonSchemaRules = (rootRule: Rule = allUnclassified): Rules => ({
   "/example": allAnnotation,
   "/examples": allAnnotation,
   "/externalDocs": allAnnotation,
-  "/deprecated": allDeprecate,
+  "/deprecated": allDeprecated,
   "/xml": {
     // TODO
     "/": allUnclassified,

--- a/src/rules/openapi3.ts
+++ b/src/rules/openapi3.ts
@@ -4,7 +4,7 @@ import { Rules, Rule } from "../types"
 import { 
   breaking, nonBreaking, unclassified, 
   allAnnotation, addNonBreaking, 
-  allBreaking, allNonBreaking, allDeprecate, annotation,
+  allBreaking, allNonBreaking, allDeprecated, annotation,
 } from "../constants"
 
 const pathArrayRules = (rules: Rules) => matchRule(rules, ({ before, after }) => {
@@ -89,7 +89,7 @@ const parametersRules: Rules = paramArrayRules({
     "/style": parameterStyleRule,
     "/description": allAnnotation,
     "/required": [breaking, nonBreaking, (ctx) => ctx.up().after.schema?.default ? nonBreaking : breakingIfAfterTrue(ctx)],
-    "/deprecated": allDeprecate,
+    "/deprecated": allDeprecated,
   }),
 })
 
@@ -99,7 +99,7 @@ const headersRules: Rules = {
     "/": [nonBreaking, breaking, breaking],
     "/description": allAnnotation,
     "/required": [breaking, nonBreaking, breakingIfAfterTrue],
-    "/deprecated": allDeprecate,
+    "/deprecated": allDeprecated,
   },
 }
 
@@ -178,7 +178,7 @@ const operationRules: Rules = {
   "/parameters": parametersRules,
   "/requestBody": requestBodiesRules,
   "/responses": responsesRules,
-  "/deprecated": allDeprecate,
+  "/deprecated": allDeprecated,
   "/security": operationSecurityRules,
   "/servers": serversRules,
 }

--- a/src/rules/swagger2.ts
+++ b/src/rules/swagger2.ts
@@ -2,7 +2,7 @@ import { breakingIf, breakingIfAfterTrue, emptySecurity, includeSecurity, matchR
 import { DiffTypeFunc, Rule, Rules } from "../types"
 import { 
   breaking, nonBreaking, allAnnotation, addNonBreaking, 
-  allBreaking, allUnclassified, onlyAddBreaking, allDeprecate,
+  allBreaking, allUnclassified, onlyAddBreaking, allDeprecated,
 } from "../constants"
 
 const maxClassifier: Rule = [
@@ -213,7 +213,7 @@ const operationRules: Rules = {
   }),
   "/parameters": parametersRules,
   "/responses": responsesRules,
-  "/deprecated": allDeprecate,
+  "/deprecated": allDeprecated,
   "/security": operationSecurityRules  
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type Diff = JsonDiff & {
   type: DiffType
 }
 
-export type DiffType = "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecate"
+export type DiffType = "breaking" | "non-breaking" | "annotation" | "unclassified" | "deprecated"
 
 export type AddDiffType = DiffType | DiffTypeFunc
 export type RemoveDiffType = DiffType | DiffTypeFunc

--- a/test/jsonschema-difftree.test.ts
+++ b/test/jsonschema-difftree.test.ts
@@ -1,5 +1,5 @@
 import { addPatch, ExampleResource, removePatch, replacePatch } from "./helpers"
-import { annotation, breaking, deprecate, DiffAction, DIFF_META_KEY, getValueByPath, nonBreaking, unclassified } from "../src"
+import { annotation, breaking, deprecated, DiffAction, DIFF_META_KEY, getValueByPath, nonBreaking, unclassified } from "../src"
 
 const exampleBefore = new ExampleResource("schema-before.yaml")
 const exapmleAfter = new ExampleResource("schema-after.yaml")
@@ -33,7 +33,7 @@ describe("Test JsonSchema difftree", () => {
     })
     expect(diffTree.properties.email[metaKey]).toMatchObject({ 
       default: { type: breaking, action: DiffAction.replace },
-      deprecated: { type: deprecate, action: DiffAction.replace },
+      deprecated: { type: deprecated, action: DiffAction.replace },
     })
     expect(diffTree.properties.items[metaKey]).toMatchObject({ 
       description: { type: annotation, action: DiffAction.replace },

--- a/test/jsonschema-merge.test.ts
+++ b/test/jsonschema-merge.test.ts
@@ -1,5 +1,5 @@
 import { addPatch, ExampleResource, removePatch, replacePatch } from "./helpers"
-import { annotation, breaking, deprecate, DiffAction, getValueByPath, nonBreaking, unclassified } from "../src"
+import { annotation, breaking, deprecated, DiffAction, getValueByPath, nonBreaking, unclassified } from "../src"
 
 const metaKey = Symbol("diff")
 const exampleBefore = new ExampleResource("schema-before.yaml")
@@ -33,7 +33,7 @@ describe("Test JsonSchema merge", () => {
     })
     expect(merged.properties.email[metaKey]).toMatchObject({ 
       default: { type: breaking, action: DiffAction.replace },
-      deprecated: { type: deprecate, action: DiffAction.replace },
+      deprecated: { type: deprecated, action: DiffAction.replace },
     })
     expect(merged.properties.items[metaKey]).toMatchObject({ 
       description: { type: annotation, action: DiffAction.replace },


### PR DESCRIPTION
Fix naming due to a more comfortable usage and types equality