### PR TITLE
fix(openapi3-rules): classification of additionalProperties, special …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-smart-diff",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Generate the diff between two API specifications (OpenAPI, AsyncAPI, JsonSchema)",
   "module": "dist/esm/index.js",
   "main": "dist/cjs/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,10 @@ export enum ClassifierType {
   deprecated = "deprecated"
 }
 
+export enum JsonSchemaLocation {
+  requestBody = "requestBody",
+}
+
 export const { breaking, nonBreaking, unclassified, annotation, deprecated } = ClassifierType
 
 // predefined classifiers

--- a/test/openapi3-diff.test.ts
+++ b/test/openapi3-diff.test.ts
@@ -1,5 +1,5 @@
-import { addPatch, ExampleResource } from "./helpers"
-import { annotation, breaking, DiffAction, nonBreaking, unclassified } from "../src"
+import { addPatch, ExampleResource } from './helpers'
+import { annotation, breaking, DiffAction, nonBreaking, unclassified } from '../src'
 
 const exampleResource = new ExampleResource("petstore.yaml")
 
@@ -156,5 +156,22 @@ describe("Test openapi 3 diff", () => {
 
     const diffs = exampleResource.diff(after)
     expect(diffs).toMatchObject([{ type: nonBreaking }, { type: nonBreaking }])
-  }) 
+  })
+
+  it("should classify as non-breaking change of additionalProperties from any type to true in request", () => {
+    const after = exampleResource.clone()
+    after.paths["/pet/{petId}"].post.requestBody.content["application/x-www-form-urlencoded"].schema.properties.customProperties.additionalProperties = true
+
+    const diffs = exampleResource.diff(after)
+    expect(diffs).toMatchObject([{ type: nonBreaking }])
+  })
+
+  it("should classify as non-breaking change of response code from 5XX to 5xx", () => {
+    const after = exampleResource.clone()
+    after.paths["/pet"].put.responses["5xx"] = after.paths["/pet"].put.responses["5XX"]
+    delete after.paths["/pet"].put.responses["5XX"]
+
+    const diffs = exampleResource.diff(after)
+    expect(diffs).toMatchObject([{ type: nonBreaking }])
+  })
 })

--- a/test/resources/petstore.yaml
+++ b/test/resources/petstore.yaml
@@ -57,6 +57,9 @@ paths:
         '405':
           description: Validation exception
           content: {}
+        '5XX':
+          description: Internal Server Error
+          content: { }
       security:
       - petstore_auth:
         - write:pets
@@ -228,6 +231,11 @@ paths:
                 status:
                   type: string
                   description: Updated status of the pet
+                customProperties:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    description: Custom additional property
       responses:
         '405':
           description: Invalid input


### PR DESCRIPTION
Fix classification of the following:
- In Request Body, there can be additionalProperties changed from any type to `true`. This change should be non-breaking;
- In operation parameters section, there can be special headers like `Accept`, `Content-Type` and `Authorization` (case insensitive). Removal of any of them is a non-breaking change as well (according to specification);
- Response codes changed from 4xx to 4XX should be non-breaking too (case insensitive);

@udamir, :)