### PR TITLE
feat: use of latest over fixed versions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.2/addon/fold/foldcode.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.2/addon/fold/indent-fold.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/api-smart-diff@1.0.6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/api-smart-diff@latest"></script>
   <!-- <script src="../dist/index.iife.js"></script> -->
 
   <style>


### PR DESCRIPTION
Since `latest` works, why not use it over fixed versions? Otherwise, I can setup some automation for when versions are pushed.